### PR TITLE
Make search disappear when scrolling down. Reappear when going up.

### DIFF
--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -46,7 +46,10 @@ export default function Header({ headerLinks }: HeaderProps) {
   }: SyntheticEvent<HTMLFormElement>) => {
     // Captures search input and button container to detect blur outside child elements
     requestAnimationFrame(() => {
-      if (!currentTarget.contains(document.activeElement)) {
+      if (
+        !currentTarget.contains(document.activeElement) &&
+        direction === 'up'
+      ) {
         setShowSearch(false);
       }
     });
@@ -59,10 +62,10 @@ export default function Header({ headerLinks }: HeaderProps) {
   };
 
   useEffect(() => {
-    if (showSearch) {
+    if (showSearch && direction === 'up') {
       searchInputRef?.current?.focus();
     }
-  }, [showSearch, searchInputRef?.current]);
+  }, [showSearch, direction, searchInputRef?.current]);
 
   // Change header links based on how menu is being displayed:
   // If !showMenu and !showSearch, then it's the normal full-width menu (b/c these vars can only be affected by buttons that are only accessible in mobile)
@@ -155,7 +158,7 @@ export default function Header({ headerLinks }: HeaderProps) {
                 )}
               </Link>
             ))}
-            mobileExpanded={showMenu || showSearch}
+            mobileExpanded={(showMenu || showSearch) && direction === 'up'}
             onToggleMobileNav={() => {
               setShowMenu(false);
               setShowSearch(false);
@@ -163,19 +166,17 @@ export default function Header({ headerLinks }: HeaderProps) {
           >
             {
               // Add a menu title to the mobile menu nav overlay
-              showMenu ? (
+              showMenu && (
                 <div className="menu-title" data-cy="cwp-menu-title">
                   <Link className="menu-link" to="/">
                     child welfare playbook
                   </Link>
                 </div>
-              ) : (
-                ''
               )
             }
             {
               // Add search bar element to otherwise empty mobile search nav overlay
-              showSearch ? (
+              showSearch && (
                 <form
                   onSubmit={submitSearch}
                   data-cy="mobile-search-form"
@@ -199,15 +200,12 @@ export default function Header({ headerLinks }: HeaderProps) {
                     type="submit"
                     className="usa-button mobile-search-button"
                     data-testid="button"
-                    autoFocus
                   >
                     <span className="mobile-header-search-icon usa-search__submit-text">
                       Search
                     </span>
                   </button>
                 </form>
-              ) : (
-                ''
               )
             }
           </PrimaryNav>

--- a/src/hooks/useScrollDirection.spec.ts
+++ b/src/hooks/useScrollDirection.spec.ts
@@ -16,7 +16,7 @@ describe('when useScrollDirection rendered', () => {
       result: { current },
     } = renderHook(() => useScrollDirection(ref));
 
-    expect(current).toBe('down');
+    expect(current).toBe('up');
     expect(ref.current).toBe(0);
   });
 });

--- a/src/hooks/useScrollDirection.ts
+++ b/src/hooks/useScrollDirection.ts
@@ -3,7 +3,8 @@ import { MutableRefObject, useEffect, useState } from 'react';
 export default function useScrollDirection(
   scrollRef: MutableRefObject<number>,
 ) {
-  const [goingUp, setGoingUp] = useState(false);
+  // Default to 'up'
+  const [goingUp, setGoingUp] = useState(true);
 
   const handleScroll = () => {
     const currentScrollY = window.scrollY;


### PR DESCRIPTION
- Needed the search menu to also have sticky header functionality with scrolling in mind.

https://user-images.githubusercontent.com/10701395/160188166-325a04b5-fce7-48d0-9b9f-818de3bf46d6.mov

