### PR TITLE
Fixed the current members menu link on about page

### DIFF
--- a/src/pages/about.tsx
+++ b/src/pages/about.tsx
@@ -74,7 +74,7 @@ export default function About() {
         addHash('Benefits of Membership', '#benefits-of-membership'),
     },
     {
-      to: `/about#freeEvaluation`,
+      to: `/about#currentMembers`,
       title: 'Current Members',
       onAnchorLinkClick: () => addHash('Current Members', '#current-members'),
     },


### PR DESCRIPTION
This pull request was created to fix the menu link on the about page. The `Current Members` link was taking users to the  `Free Evaluation` section. I have updated this in the code and the link will now jump down to the `Current Members` section like it should. 