### PR TITLE
Update config.yml for Netlify admin access

### DIFF
--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -2,7 +2,6 @@ backend:
   name: 'github'
   repo: 'MarinaNitze/progress-dashboard'
   branch: 'main'
-  base_url: https://charming-salamander-5a550e.netlify.app
 publish_mode: 'editorial_workflow'
 
 media_folder: 'src/images'


### PR DESCRIPTION
Netlify configurations need to be updated to allow for Netlify admin access. The base url configuration was old and causing a redirect to the wrong url which was causing Netlify admin site to register as a 404 error.