### PR TITLE
Remove blog link

### DIFF
--- a/src/_data/navigation.yaml
+++ b/src/_data/navigation.yaml
@@ -8,7 +8,5 @@ items:
     url: "/compare"
   - text: About
     url: "/about"
-  - text: Blog
-    url: "/blog"
   - text: Search
     url: "/search"


### PR DESCRIPTION
Re-issue of #361 , taking the Airtable removal out of the critical path.