### PR TITLE
Reduce scroll on Topic pages

### DIFF
--- a/src/topics/index.njk
+++ b/src/topics/index.njk
@@ -39,11 +39,11 @@ title: Topics
         <ul class="grid grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 xxl:grid-cols-5 gap-4">
             <template x-for="topic in filteredTopics" :key="topic.title">
                 <li class="flex">
-                    <a class="rounded-lg overflow-hidden bg-gray-200 group text-[21px] text-navy hover:bg-yellow hover:underline w-full bg-[#F4B413] block text-center font-bold flex flex-col" :href="'/topics/' + topic.title">
-                        <div class="h-[120px] flex items-center justify-center">
+                    <a class="rounded-lg overflow-hidden bg-gray-200 group text-[16px] text-navy hover:bg-yellow hover:underline w-full bg-[#F4B413] block text-center font-bold flex flex-col" :href="'/topics/' + topic.title">
+                        <div class="h-[50px] flex items-center justify-center">
                             <img :src="topic.image.split(/^\/?src/).join('')" role="presentation" />
                         </div>
-                        <div class="rounded-b-lg flex-1 p-8 bg-yellow" x-text="topic.hero.title"></div>
+                        <div class="rounded-b-lg flex-1 p-4 bg-yellow" x-text="topic.hero.title"></div>
                     </a>
                 </li>
             </template>


### PR DESCRIPTION
This is part of the ["Topics" page improvement ticket](https://airtable.com/appqzI66iQfGwIWBE/tbl0jbDAYybKMWIMM/viwoU4VmYI8RFc49L/rec92I5Ni9NNTyTAh?blocks=hide), both with the purpose of reducing scroll.

The changes include:

- Shorten topic tile height
- Remove search