### PR TITLE
Add recommendation links to topic pages

### DIFF
--- a/src/_data/topics.yml
+++ b/src/_data/topics.yml
@@ -141,7 +141,6 @@ topics:
       - involve-kin-prior-to-removal
       - leverage-the-court-system-to-encourage-kin
       - test-your-communications-with-real-kin
-    what: "\ \n"
   - hero:
       backgroundColor: light
       title: Foster Parent Compensation

--- a/src/_data/topics.yml
+++ b/src/_data/topics.yml
@@ -477,24 +477,11 @@ topics:
       * **Talk to your existing families** Getting their feedback early and often can help address smaller issues early on, before they blow up into big issues that make them want to quit. Real relationships are far superior to mailing out surveys.
     recommendations:
       - measure-retention-carefully
-      - ideas-for-recognizing-resource-families
-      - resource-family-support-groups
-      - accompany-resource-parents-to-meetings
       - check-in-frequently-on-first-placements
       - provide-childcare-at-resource-parent-events
-      - provide-regular-updates-to-resource-parents
       - welcome-bag-for-new-resource-parents
-      - make-it-easy-for-resource-parents-to-meet-new-licensing-requirements
-      - support-resource-parents-through-allegations
-      - mentors-for-resource-parents
-      - give-resource-families-opportunities-to-be-heard
-      - foster-a-sense-of-community-amongst-resource-families
       - check-in-with-your-resource-families-regularly
-      - financial-supports-for-resource-families
-      - normalize-respite
       - identify-natural-supports-for-caregivers
-      - proactively-avoid-resource-family-burnout
-      - create-a-resource-parent-handbook
   - hero:
       backgroundColor: light
       title: Sibling Connections

--- a/src/topics/topic.njk
+++ b/src/topics/topic.njk
@@ -63,7 +63,7 @@ permalink: "/topics/{{ topic.title }}/"
                         </a>
                     </li>
                 {% endif %}
-                {% if topic.why %}
+                {% if topic.what %}
                     <li>
                         <a class="text-lg hover:underline text-white hover:text-[#fe6659]" href="#what">
                             {% if topic.whatTitle %}
@@ -71,6 +71,13 @@ permalink: "/topics/{{ topic.title }}/"
                             {% else %}
                                 What we can do
                             {% endif %}
+                        </a>
+                    </li>
+                {% endif %}
+                {% if topic.recommendations %}
+                    <li>
+                        <a class="text-lg hover:underline text-white hover:text-[#fe6659]" href="#recommendations">
+                            Recommendations
                         </a>
                     </li>
                 {% endif %}
@@ -119,6 +126,30 @@ permalink: "/topics/{{ topic.title }}/"
                         </span>
                     </h2>
                     {{ topic.what | markdown | safe }}
+                </div>
+            {% endif %}
+
+            {% if topic.recommendations %}
+                 <div class="mb-12">
+                    <h2 id="how-programs-are-doing-this" class="text-4xl font-bold mb-8 mt-0 font-serif">
+                        <span class="border-b-[4px] border-[#fe6659] pb-2">
+                            Recommendations
+                        </span>
+                    </h2>
+
+                    <ul>
+                    {% for rec in topic.recommendations %}
+                        <li>
+                            <a href="/recommendations/{{ rec }}/">
+                                {% for item in recommendations.recommendations %}
+                                    {% if item.title === rec %}
+                                        {{ item.heading }}
+                                    {% endif %}
+                                {% endfor %}
+                            </a>
+                        </li>
+                    {% endfor %}
+                    </ul>
                 </div>
             {% endif %}
         </div>


### PR DESCRIPTION
This restores recommendation links to topic pages. You can [preview these changes here.](https://deploy-preview-374--charming-salamander-5a550e.netlify.app/topics)

### Known issues

[The Retention topic page](https://deploy-preview-374--charming-salamander-5a550e.netlify.app/topics/retention/) contains many blank list items. This is because it refers to  recommendations that no longer exist, including:

- ideas-for-recognizing-resource-families
- resource-family-support-groups
- accompany-resource-parents-to-meetings
- provide-regular-updates-to-resource-parents
- make-it-easy-for-resource-parents-to-meet-new-licensing-requirements
- support-resource-parents-through-allegations
- mentors-for-resource-parents
- give-resource-families-opportunities-to-be-heard
- foster-a-sense-of-community-amongst-resource-families
- financial-supports-for-resource-families
- normalize-respite
- proactively-avoid-resource-family-burnout
- create-a-resource-parent-handbook

@MarinaNitze Let me know if you'd like me to update these links or remove them entirely.

Also, it looks like the old design lists recommendations under the section header "How programs are doing this." But this wraps to two lines in the navigation sidebar. So I used the header "Recommendations" instead.

![CleanShot 2025-03-03 at 11 42 28@2x](https://github.com/user-attachments/assets/9c71a4cb-e546-4639-89ac-b174ecee412b)